### PR TITLE
Fix: 'KeyError' 

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -1,6 +1,5 @@
 from pytest_testconfig import config
 
-valore = config['something']['a_value']
 
 def do_something():
-    return valore
+    return config['something']['a_value']

--- a/test_something.py
+++ b/test_something.py
@@ -1,5 +1,12 @@
 import pytest
 from pytest_testconfig import config
 
+from lib import do_something
+
+
 def test_something():
     assert config['something']['a_value'] == "the value"
+
+
+def test_something2():
+    assert do_something() == "the value"


### PR DESCRIPTION
Hello, @andreabisello! It looks like i fixed your problem at https://github.com/wojole/pytest-testconfig/issues/8. Your comment [here](https://github.com/wojole/pytest-testconfig/issues/8#issuecomment-603870018).
What i have done:
- Removed constant initialization with plugin config parser; 
- Moved config parser to 'do_something' method; 
- Added test_something2 to test 'do_something' method works. 
- Resolved https://github.com/wojole/pytest-testconfig/issues/8

Now test_something.py passes with old 'test_something' and new 'test_something2'.

The problem was with constant initialization 'valore' which was not in 'test_' files. Seems that config parser cant be defined as a constant not in test modules.

Hope this helps! 
If not: i think you should create another issue with new description that you want to initialize config parser as a constant, not in test modules or in pytest plugins like conftest.py.

Good luck, i wish you have an easy coding!